### PR TITLE
Improve support for unsigned 16 bit port numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+.vs
 
 # Build results
 [Dd]ebug/

--- a/src/Snifter/AppOptions.cs
+++ b/src/Snifter/AppOptions.cs
@@ -19,8 +19,8 @@ namespace Snifter
         public int? FilterProtocol { get; set; }
         public IPAddress FilterSourceAddress { get; set; }
         public IPAddress FilterDestAddress { get; set; }
-        internal UInt16? FilterSourcePort { get; set; }
-        internal UInt16? FilterDestPort { get; set; }
+        internal ushort? FilterSourcePort { get; set; }
+        internal ushort? FilterDestPort { get; set; }
 
         public AppOptions()
         {

--- a/src/Snifter/AppOptions.cs
+++ b/src/Snifter/AppOptions.cs
@@ -34,8 +34,8 @@ namespace Snifter
                 { "p=|protocol", "Filter packets by IANA registered protocol number", x => this.FilterProtocol = Int32.Parse(x) },
                 { "s=|source-address", "Filter packets by source IP address", x => this.FilterSourceAddress = IPAddress.Parse(x) },
                 { "d=|dest-address", "Filter packets by destination IP address", x => this.FilterDestAddress = IPAddress.Parse(x) },
-                { "x=|source-port", "Filter packets by source port number", x => this.FilterSourcePort = UInt16.Parse(x) },
-                { "y=|dest-port", "Filter packets by destination port number", x => this.FilterDestPort = UInt16.Parse(x) },
+                { "x=|source-port", "Filter packets by source port number", x => this.FilterSourcePort = ushort.Parse(x) },
+                { "y=|dest-port", "Filter packets by destination port number", x => this.FilterDestPort = ushort.Parse(x) },
                 { "h|?|help", "Show command line options", x => this.ShowHelp = x != null }
             };
 

--- a/src/Snifter/AppOptions.cs
+++ b/src/Snifter/AppOptions.cs
@@ -19,8 +19,8 @@ namespace Snifter
         public int? FilterProtocol { get; set; }
         public IPAddress FilterSourceAddress { get; set; }
         public IPAddress FilterDestAddress { get; set; }
-        public short? FilterSourcePort { get; set; }
-        public short? FilterDestPort { get; set; }
+        internal UInt16? FilterSourcePort { get; set; }
+        internal UInt16? FilterDestPort { get; set; }
 
         public AppOptions()
         {
@@ -34,8 +34,8 @@ namespace Snifter
                 { "p=|protocol", "Filter packets by IANA registered protocol number", x => this.FilterProtocol = Int32.Parse(x) },
                 { "s=|source-address", "Filter packets by source IP address", x => this.FilterSourceAddress = IPAddress.Parse(x) },
                 { "d=|dest-address", "Filter packets by destination IP address", x => this.FilterDestAddress = IPAddress.Parse(x) },
-                { "x=|source-port", "Filter packets by source port number", x => this.FilterSourcePort = Int16.Parse(x) },
-                { "y=|dest-port", "Filter packets by destination port number", x => this.FilterDestPort = Int16.Parse(x) },
+                { "x=|source-port", "Filter packets by source port number", x => this.FilterSourcePort = UInt16.Parse(x) },
+                { "y=|dest-port", "Filter packets by destination port number", x => this.FilterDestPort = UInt16.Parse(x) },
                 { "h|?|help", "Show command line options", x => this.ShowHelp = x != null }
             };
 

--- a/src/Snifter/IPPacket.cs
+++ b/src/Snifter/IPPacket.cs
@@ -10,8 +10,8 @@ namespace Snifter
         public int Protocol { get; private set; }
         public IPAddress SourceAddress { get; private set; }
         public IPAddress DestAddress { get; private set; }
-        internal UInt16 SourcePort { get; private set; }
-        internal UInt16 DestPort { get; private set; }
+        internal ushort SourcePort { get; private set; }
+        internal ushort DestPort { get; private set; }
 
         public IPPacket(byte[] data)
         {

--- a/src/Snifter/IPPacket.cs
+++ b/src/Snifter/IPPacket.cs
@@ -10,8 +10,8 @@ namespace Snifter
         public int Protocol { get; private set; }
         public IPAddress SourceAddress { get; private set; }
         public IPAddress DestAddress { get; private set; }
-        public short SourcePort { get; private set; }
-        public short DestPort { get; private set; }
+        internal UInt16 SourcePort { get; private set; }
+        internal UInt16 DestPort { get; private set; }
 
         public IPPacket(byte[] data)
         {
@@ -29,8 +29,8 @@ namespace Snifter
 
                 if (Enum.IsDefined(typeof (ProtocolsWithPort), this.Protocol))
                 {
-                    this.SourcePort = BitConverter.ToInt16(data, this.HeaderLength);
-                    this.DestPort = BitConverter.ToInt16(data, this.HeaderLength + 2);
+                    this.SourcePort = BitConverter.ToUInt16(data, this.HeaderLength);
+                    this.DestPort = BitConverter.ToUInt16(data, this.HeaderLength + 2);
                 }
             }
         }


### PR DESCRIPTION
In my previous experience with Snifter, I had to pull some tricks to get port matching correct, I believe this PR should fix this.
> To monitor both sides of a port 8096 conversation, I had to use: snifter -i 3 -x -24545 -y -24545